### PR TITLE
Making the gem to work with Rails version 4.0.0

### DIFF
--- a/lib/active_type/no_table.rb
+++ b/lib/active_type/no_table.rb
@@ -7,6 +7,10 @@ module ActiveType
 
     module ClassMethods
 
+      def column_types
+        []
+      end
+
       def columns
         []
       end


### PR DESCRIPTION
I tried the gem on our existing Rails 4.0.0 project. 

After incorporating it into the project, I started a rails console and tried to make a new object using the following code:

class SignIn < ActiveType::Object

  attribute :email, :string
  attribute :nickname, :string, default: proc { email.split('@').first }

end

SignIn.new(email: "tobias@example.org")

---

This returned the following error: 
TypeError: can't dup NilClass
	from /Users/dave/.rvm/gems/ruby-2.0.0-p594/gems/activerecord-4.0.0/lib/active_record/core.rb:185:in `dup'

When I went into core.rb I found the problem. In version 4.0.0 dup method is being called on column_types variable. The problem is that column_types is nil. So basically calling column_types.dup throws an exception. 
I went through Rails 4.1 and 4.2. There wouldn't a problem using the gem in those versions, because there is no call to dup.

The simple fix I introduced tries to solve the problem already stated in Rails version 4.0.0. It makes calling column_types to return [] instead of nil. So calling .dup on it would not be a problem anymore.