### PR TITLE
Use native database type for type casting in pg

### DIFF
--- a/lib/active_type/type_caster.rb
+++ b/lib/active_type/type_caster.rb
@@ -65,6 +65,14 @@ module ActiveType
       class DelegateToType
 
         def initialize(type, connection)
+          # The specified type (e.g. "string") may not necessary match the
+          # native type ("varchar") expected by the connection adapter.
+          # PostgreSQL is one of these. Perform a translation if the adapter
+          # supports it.
+          if !type.nil? && connection.respond_to?(:native_database_types)
+            native_type = connection.native_database_types[type.to_sym]
+            type = native_type.fetch(:name) unless native_type.nil?
+          end
           @active_record_type = connection.lookup_cast_type(type)
         end
 


### PR DESCRIPTION
Rails 4.2.0 with pg 0.18.1 delegates to the database to look up data types. The database doesn't recognize Rails-style datatypes like `:string`; it expects native types like `varchar`.

The patch translates the Rails type to the PG type using the `native_database_types` lookup table that the PG adapter provides.

Should fix #19.