### PR TITLE
[fixes #25] dont crash for database types without casting rules

### DIFF
--- a/lib/active_type/type_caster.rb
+++ b/lib/active_type/type_caster.rb
@@ -71,7 +71,12 @@ module ActiveType
           # supports it.
           if !type.nil? && connection.respond_to?(:native_database_types)
             native_type = connection.native_database_types[type.to_sym]
-            type = native_type.fetch(:name) unless native_type.nil?
+            if native_type && native_type[:name]
+              type = native_type[:name]
+            else
+              # unknown type, we just dont cast
+              type = nil
+            end
           end
           @active_record_type = connection.lookup_cast_type(type)
         end

--- a/spec/active_type/object_spec.rb
+++ b/spec/active_type/object_spec.rb
@@ -79,6 +79,10 @@ module ObjectSpec
 
   end
 
+  class ObjectWithUnsupportedTypes < Object
+    attribute :virtual_array, :array
+    attribute :virtual_hash, :hash
+  end
 
 end
 
@@ -100,6 +104,13 @@ describe ActiveType::Object do
 
   describe 'accessors' do
     it_should_behave_like 'ActiveRecord-like accessors', { :virtual_string => "string", :virtual_integer => 100, :virtual_time => Time.now, :virtual_date => Date.today, :virtual_boolean => true }
+  end
+
+  describe 'unsupported types' do
+    subject { ObjectSpec::ObjectWithUnsupportedTypes.new }
+
+    it_should_behave_like 'ActiveRecord-like mass assignment', { :virtual_hash => {'foo' => 'bar'}, :virtual_array => ['foo', 'bar'] }
+    it_should_behave_like 'ActiveRecord-like accessors', { :virtual_hash => {'foo' => 'bar'}, :virtual_array => ['foo', 'bar'] }
   end
 
   describe 'overridable attributes' do


### PR DESCRIPTION
Don't try to look up unknown data types via the db adapter. Instead, we will silently ignore such data types.