### PR TITLE
Fix bug 'can't dup NilClass', when ActiveType::Object has no attributes

### DIFF
--- a/lib/active_type/virtual_attributes.rb
+++ b/lib/active_type/virtual_attributes.rb
@@ -96,7 +96,7 @@ module ActiveType
 
     def initialize_dup(other)
       @virtual_attributes_cache = {}
-      @virtual_attributes = VirtualAttributes.deep_dup(@virtual_attributes)
+      @virtual_attributes = VirtualAttributes.deep_dup(virtual_attributes)
 
       super
     end


### PR DESCRIPTION
```ruby
class SignUp < ActiveType::Record[User]
  # has no attributes
end

SignIn.new().dup # raise error "can't dup NilClass"
```
