### PR TITLE
Fixing dup when called prior to virtual attributes being initialized

### DIFF
--- a/lib/active_type/virtual_attributes.rb
+++ b/lib/active_type/virtual_attributes.rb
@@ -96,7 +96,7 @@ module ActiveType
 
     def initialize_dup(other)
       @virtual_attributes_cache = {}
-      @virtual_attributes = VirtualAttributes.deep_dup(@virtual_attributes)
+      @virtual_attributes = VirtualAttributes.deep_dup(virtual_attributes)
 
       super
     end

--- a/spec/shared_examples/dupable.rb
+++ b/spec/shared_examples/dupable.rb
@@ -26,6 +26,10 @@ shared_examples_for "a class supporting dup for attributes" do |klass|
       duped.attribute.should == { :foo => "baz" }
     end
 
+    it 'returns an object when attributes have not been referenced' do
+      subject.dup
+    end
+
   end
 
 end


### PR DESCRIPTION
This pull request addresses the following exception when `dup` is called on an ActiveType::Record before the virtual attributes are initialized.

Prior to the fix, the newly added test failed like this:

```
  1) ActiveType::Object duping it should behave like a class supporting dup for attributes #dup returns an object when attributes have not been referenced
     Failure/Error: subject.dup
     TypeError:
       can't dup NilClass
     Shared Example Group: "a class supporting dup for attributes" called from ./spec/active_type/object_spec.rb:315
     # ./lib/active_type/virtual_attributes.rb:82:in `dup'
     # ./lib/active_type/virtual_attributes.rb:82:in `deep_dup'
     # ./lib/active_type/virtual_attributes.rb:99:in `initialize_dup'
     # ./spec/shared_examples/dupable.rb:30:in `dup'
     # ./spec/shared_examples/dupable.rb:30:in `block (3 levels) in <top (required)>'
```

The fix is somewhat obvious - use the accessor instead of referencing the instance variable directly to ensure it's initialized.


