### PR TITLE
Don't type cast mysql boolean as tinyint. Hopefully fixes #42 and #46.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ gemfile:
   - gemfiles/Gemfile.4.0
   - gemfiles/Gemfile.4.1
   - gemfiles/Gemfile.4.2.1
-  - gemfiles/Gemfile.4.2.1.pg
   - gemfiles/Gemfile.4.2.1.mysql2
+  - gemfiles/Gemfile.4.2.1.pg
 before_script:
   - psql -c 'create database active_type_test;' -U postgres
   - mysql -e 'create database IF NOT EXISTS active_type_test;'
@@ -31,9 +31,15 @@ matrix:
     - rvm: "1.8.7"
       gemfile: gemfiles/Gemfile.4.2.1
     - rvm: "1.8.7"
+      gemfile: gemfiles/Gemfile.4.2.1.mysql2
+    - rvm: "1.8.7"
       gemfile: gemfiles/Gemfile.4.2.1.pg
     - rvm: "1.9.3"
+      gemfile: gemfiles/Gemfile.4.2.1.mysql2
+    - rvm: "1.9.3"
       gemfile: gemfiles/Gemfile.4.2.1.pg
+    - rvm: "2.0.0"
+      gemfile: gemfiles/Gemfile.4.2.1.mysql2
     - rvm: "2.0.0"
       gemfile: gemfiles/Gemfile.4.2.1.pg
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,10 @@ gemfile:
   - gemfiles/Gemfile.4.1
   - gemfiles/Gemfile.4.2.1
   - gemfiles/Gemfile.4.2.1.pg
+  - gemfiles/Gemfile.4.2.1.mysql2
 before_script:
   - psql -c 'create database active_type_test;' -U postgres
+  - mysql -e 'create database IF NOT EXISTS active_type_test;'
 script: bundle exec rspec spec
 notifications:
   email:

--- a/gemfiles/Gemfile.4.2.1.mysql2
+++ b/gemfiles/Gemfile.4.2.1.mysql2
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+gem 'activerecord', '~>4.2.1'
+gem 'rspec', '<2.99'
+gem 'mysql2', '~> 0.3.17'
+
+gem 'active_type', :path => '..'

--- a/gemfiles/Gemfile.4.2.1.mysql2.lock
+++ b/gemfiles/Gemfile.4.2.1.mysql2.lock
@@ -1,0 +1,52 @@
+PATH
+  remote: ..
+  specs:
+    active_type (0.4.2)
+      activerecord (>= 3.2)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activemodel (4.2.1)
+      activesupport (= 4.2.1)
+      builder (~> 3.1)
+    activerecord (4.2.1)
+      activemodel (= 4.2.1)
+      activesupport (= 4.2.1)
+      arel (~> 6.0)
+    activesupport (4.2.1)
+      i18n (~> 0.7)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
+    arel (6.0.0)
+    builder (3.2.2)
+    diff-lcs (1.2.5)
+    i18n (0.7.0)
+    json (1.8.3)
+    minitest (5.7.0)
+    mysql2 (0.3.20)
+    rspec (2.14.1)
+      rspec-core (~> 2.14.0)
+      rspec-expectations (~> 2.14.0)
+      rspec-mocks (~> 2.14.0)
+    rspec-core (2.14.8)
+    rspec-expectations (2.14.5)
+      diff-lcs (>= 1.1.3, < 2.0)
+    rspec-mocks (2.14.6)
+    thread_safe (0.3.5)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  active_type!
+  activerecord (~> 4.2.1)
+  mysql2 (~> 0.3.17)
+  rspec (< 2.99)
+
+BUNDLED WITH
+   1.10.6

--- a/lib/active_type/type_caster.rb
+++ b/lib/active_type/type_caster.rb
@@ -68,8 +68,8 @@ module ActiveType
           # The specified type (e.g. "string") may not necessary match the
           # native type ("varchar") expected by the connection adapter.
           # PostgreSQL is one of these. Perform a translation if the adapter
-          # supports it.
-          if !type.nil? && connection.respond_to?(:native_database_types)
+          # supports it (but don't turn a mysql boolean into a tinyint).
+          if !type.nil? && !(type == :boolean) && connection.respond_to?(:native_database_types)
             native_type = connection.native_database_types[type.to_sym]
             if native_type && native_type[:name]
               type = native_type[:name]

--- a/spec/support/database.rb
+++ b/spec/support/database.rb
@@ -3,10 +3,16 @@ begin
   ActiveRecord::Base.establish_connection(:adapter => 'sqlite3', :database => ':memory:')
 rescue Gem::LoadError
   # pg?
-  if ENV['TRAVIS']
-    ActiveRecord::Base.establish_connection(:adapter => 'postgresql', :database => 'active_type_test', :username => 'postgres')
-  else
-    ActiveRecord::Base.establish_connection(:adapter => 'postgresql', :database => 'active_type_test')
+  if ENV['BUNDLE_GEMFILE'] =~ /pg/
+    if ENV['TRAVIS']
+      ActiveRecord::Base.establish_connection(:adapter => 'postgresql', :database => 'active_type_test', :username => 'postgres')
+    else
+      ActiveRecord::Base.establish_connection(:adapter => 'postgresql', :database => 'active_type_test')
+    end
+  end
+  # mysql2?
+  if ENV['BUNDLE_GEMFILE'] =~ /mysql2/
+    ActiveRecord::Base.establish_connection(:adapter => 'mysql2', :encoding => 'utf8', :database => 'active_type_test')
   end
 
   connection = ::ActiveRecord::Base.connection


### PR DESCRIPTION
I encountered some problems when using boolean attributes with a mysql2 database adapter. Seemed to be because:

    ActiveRecord::Base.connection.native_database_types[:boolean][:name]
    #=> "tinyint"

and this was causing it to cast values to/from tinyint values (Fixnum) rather than to/from booleans.

I've stopped it from looking up `native_database_type` for booleans, and this seems to have fixed it. Also attempted to cover mysql2 in the tests (works locally, we'll see whether it works with travis...).