### PR TITLE
Fix after_commit callbacks for ActiveType::Object on Rails 4

### DIFF
--- a/lib/active_type/no_table.rb
+++ b/lib/active_type/no_table.rb
@@ -77,6 +77,7 @@ module ActiveType
       end
     else
       def _create_record(*)
+        @new_record = false
         true
       end
 

--- a/spec/active_type/object_spec.rb
+++ b/spec/active_type/object_spec.rb
@@ -57,6 +57,7 @@ module ObjectSpec
     before_save :before_save_callback
     before_validation :before_validation_callback
     after_save :after_save_callback
+    after_commit :after_commit_callback
 
     def before_save_callback
     end
@@ -65,6 +66,9 @@ module ObjectSpec
     end
 
     def after_save_callback
+    end
+
+    def after_commit_callback
     end
 
   end
@@ -332,9 +336,9 @@ describe ActiveType::Object do
       subject.save
     end
 
-    %w[before_validation before_save after_save].each do |callback|
+    %w[before_validation before_save after_save after_commit].each do |callback|
 
-      it "calls #{callback}" do
+      it "calls #{callback}", :rollback => false do
         subject.should_receive("#{callback}_callback")
 
         subject.save.should be_true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,7 @@ Dir["#{File.dirname(__FILE__)}/shared_examples/*.rb"].each {|f| require f}
 
 RSpec.configure do |config|
   config.around do |example|
+    next example.run unless example.metadata.fetch(:rollback, true)
     ActiveRecord::Base.transaction do
       begin
         example.run


### PR DESCRIPTION
Fixes #47.

In order to test an `after_commit` hook, the test can't be run within a transaction wrapper, which by default is being applied to all RSpec examples. To work around this, I added a `:rollback => false` RSpec metadata to disable the wrapper on a per-example basis.

For ActiveType::Object, it is OK to commit the transaction, because there is no backing table that will affected.