### PR TITLE
make inspect method return more useful information

### DIFF
--- a/lib/active_type/no_table.rb
+++ b/lib/active_type/no_table.rb
@@ -42,29 +42,6 @@ module ActiveType
       []
     end
 
-    def attribute_for_inspect(attr_name)
-      value = read_virtual_attribute(attr_name)
-
-      if value.is_a?(String) && value.length > 50
-        "#{value[0, 50]}...".inspect
-      elsif value.is_a?(Date) || value.is_a?(Time)
-        %("#{value.to_s(:db)}")
-      elsif value.is_a?(Array) && value.size > 10
-        inspected = value.first(10).inspect
-        %(#{inspected[0...-1]}, ...])
-      else
-        value.inspect
-      end
-    end
-
-    # Returns the contents of the record as a nicely formatted string.
-    def inspect
-      inspection = self.class._virtual_column_names.collect { |name|
-                         "#{name}: #{attribute_for_inspect(name)}"
-                     }.compact.join(", ")
-      "#<#{self.class} #{inspection}>"
-    end
-
     def transaction(&block)
       @_current_transaction_records ||= []
       yield

--- a/lib/active_type/no_table.rb
+++ b/lib/active_type/no_table.rb
@@ -42,6 +42,29 @@ module ActiveType
       []
     end
 
+    def attribute_for_inspect(attr_name)
+      value = read_virtual_attribute(attr_name)
+
+      if value.is_a?(String) && value.length > 50
+        "#{value[0, 50]}...".inspect
+      elsif value.is_a?(Date) || value.is_a?(Time)
+        %("#{value.to_s(:db)}")
+      elsif value.is_a?(Array) && value.size > 10
+        inspected = value.first(10).inspect
+        %(#{inspected[0...-1]}, ...])
+      else
+        value.inspect
+      end
+    end
+
+    # Returns the contents of the record as a nicely formatted string.
+    def inspect
+      inspection = self.class._virtual_column_names.collect { |name|
+                         "#{name}: #{attribute_for_inspect(name)}"
+                     }.compact.join(", ")
+      "#<#{self.class} #{inspection}>"
+    end
+
     def transaction(&block)
       @_current_transaction_records ||= []
       yield

--- a/lib/active_type/virtual_attributes.rb
+++ b/lib/active_type/virtual_attributes.rb
@@ -181,6 +181,16 @@ module ActiveType
       virtual_attributes[name] = value
     end
 
+
+    # Returns the contents of the record as a nicely formatted string.
+    def inspect
+      inspection = self.class._virtual_column_names.collect { |name|
+                         "#{name}: #{self.class.attribute_for_inspect(read_virtual_attribute(name))}"
+                     }.compact.join(", ")
+      "#<#{self.class} #{inspection}>"
+    end
+
+
     module ClassMethods
 
       def _virtual_column(name)
@@ -226,6 +236,20 @@ module ActiveType
         type = args.first
 
         Builder.new(self, generated_virtual_attribute_methods).build(name, type, options)
+      end
+
+      def attribute_for_inspect(value)
+
+        if value.is_a?(String) && value.length > 50
+          "#{value[0, 50]}...".inspect
+        elsif value.is_a?(Date) || value.is_a?(Time)
+          %("#{value.to_s(:db)}")
+        elsif value.is_a?(Array) && value.size > 10
+          inspected = value.first(10).inspect
+          %(#{inspected[0...-1]}, ...])
+        else
+          value.inspect
+        end
       end
 
     end

--- a/lib/active_type/virtual_attributes.rb
+++ b/lib/active_type/virtual_attributes.rb
@@ -186,7 +186,7 @@ module ActiveType
     def inspect
       inspection = self.class._virtual_column_names.collect { |name|
                          "#{name}: #{self.class.attribute_for_inspect(read_virtual_attribute(name))}"
-                     }.compact.join(", ")
+                     }.sort.compact.join(", ")
       "#<#{self.class} #{inspection}>"
     end
 

--- a/spec/active_type/object_spec.rb
+++ b/spec/active_type/object_spec.rb
@@ -213,7 +213,7 @@ describe ActiveType::Object do
       subject.virtual_boolean = true
       subject.virtual_attribute = OpenStruct.new({:test => "openstruct"})
 
-        expect(subject.inspect).to eq("#<ObjectSpec::Object virtual_string: \"string\", virtual_integer: 17, virtual_time: \"#{Time.now.to_s(:db)}\", virtual_date: \"#{Date.today}\", virtual_boolean: true, virtual_attribute: #<OpenStruct test=\"openstruct\">>")
+      expect(subject.inspect).to eq("#<ObjectSpec::Object virtual_attribute: #<OpenStruct test=\"openstruct\">, virtual_boolean: true, virtual_date: \"#{Date.today}\", virtual_integer: 17, virtual_string: \"string\", virtual_time: \"#{Time.now.to_s(:db)}\">")
     end
 
   end

--- a/spec/active_type/object_spec.rb
+++ b/spec/active_type/object_spec.rb
@@ -202,6 +202,21 @@ describe ActiveType::Object do
 
   end
 
+  describe '#inspect' do
+
+    it 'returns the contents of the object as a nicely formatted string' do
+      subject.virtual_string = "string"
+      subject.virtual_integer = 17
+      subject.virtual_time = Time.now
+      subject.virtual_date = Date.today
+      subject.virtual_boolean = true
+      subject.virtual_attribute = OpenStruct.new({test: "openstruct"})
+    
+        expect(subject.inspect).to eq("#<ObjectSpec::Object virtual_string: \"string\", virtual_integer: 17, virtual_time: \"#{Time.now.to_s(:db)}\", virtual_date: \"#{Date.today}\", virtual_boolean: true, virtual_attribute: #<OpenStruct test=\"openstruct\">>")
+    end
+
+  end
+
   describe '#attributes' do
 
     it 'returns a hash of virtual attributes' do

--- a/spec/active_type/object_spec.rb
+++ b/spec/active_type/object_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'ostruct'
 
 module ObjectSpec
 
@@ -210,8 +211,8 @@ describe ActiveType::Object do
       subject.virtual_time = Time.now
       subject.virtual_date = Date.today
       subject.virtual_boolean = true
-      subject.virtual_attribute = OpenStruct.new({test: "openstruct"})
-    
+      subject.virtual_attribute = OpenStruct.new({:test => "openstruct"})
+
         expect(subject.inspect).to eq("#<ObjectSpec::Object virtual_string: \"string\", virtual_integer: 17, virtual_time: \"#{Time.now.to_s(:db)}\", virtual_date: \"#{Date.today}\", virtual_boolean: true, virtual_attribute: #<OpenStruct test=\"openstruct\">>")
     end
 

--- a/spec/active_type/record_spec.rb
+++ b/spec/active_type/record_spec.rb
@@ -162,7 +162,7 @@ describe ActiveType::Record do
       subject.virtual_boolean = true
       subject.virtual_attribute = OpenStruct.new({:test => "openstruct"})
 
-        expect(subject.inspect).to eq("#<RecordSpec::Record virtual_string: \"string\", virtual_integer: 17, virtual_time: \"#{Time.now.to_s(:db)}\", virtual_date: \"#{Date.today}\", virtual_boolean: true, virtual_attribute: #<OpenStruct test=\"openstruct\">>")
+      expect(subject.inspect).to eq("#<RecordSpec::Record virtual_attribute: #<OpenStruct test=\"openstruct\">, virtual_boolean: true, virtual_date: \"#{Date.today}\", virtual_integer: 17, virtual_string: \"string\", virtual_time: \"#{Time.now.to_s(:db)}\">")
     end
 
   end

--- a/spec/active_type/record_spec.rb
+++ b/spec/active_type/record_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'ostruct'
 
 module RecordSpec
 
@@ -149,6 +150,21 @@ describe ActiveType::Record do
     describe 'untyped columns' do
       it_should_behave_like 'an untyped column', :virtual_attribute
     end
+  end
+
+  describe '#inspect' do
+
+    it 'returns the contents of the object as a nicely formatted string' do
+      subject.virtual_string = "string"
+      subject.virtual_integer = 17
+      subject.virtual_time = Time.now
+      subject.virtual_date = Date.today
+      subject.virtual_boolean = true
+      subject.virtual_attribute = OpenStruct.new({:test => "openstruct"})
+
+        expect(subject.inspect).to eq("#<RecordSpec::Record virtual_string: \"string\", virtual_integer: 17, virtual_time: \"#{Time.now.to_s(:db)}\", virtual_date: \"#{Date.today}\", virtual_boolean: true, virtual_attribute: #<OpenStruct test=\"openstruct\">>")
+    end
+
   end
 
   describe '#attributes' do


### PR DESCRIPTION
When I'm debugging I find it convenient to use the inspect method on objects. Currently only the object name is returned for active_type objects. This code is based on ActiveRecord and it returns names and values of attributes.

I've only started using active_type recently so I might have put the code in the wrong place or something like that.

Thanks!