### PR TITLE
Fix AR config issues [fixes #72]

### DIFF
--- a/lib/active_type.rb
+++ b/lib/active_type.rb
@@ -1,14 +1,31 @@
 # encoding: utf-8
 
 require 'active_type/version'
-require 'active_record'
-require 'active_type/util'
-require 'active_type/record'
-require 'active_type/object'
 
-if ActiveRecord::VERSION::STRING == '4.2.0'
-  raise(<<-MESSAGE.strip_heredoc)
-    ActiveType is not compatible with ActiveRecord 4.2.0. Please upgrade to 4.2.1
-    For details see https://github.com/makandra/active_type/issues/31
-  MESSAGE
+
+load_now = proc do
+  require 'active_type/util'
+  require 'active_type/record'
+  require 'active_type/object'
+
+  if ActiveRecord::VERSION::STRING == '4.2.0'
+    raise(<<-MESSAGE.strip_heredoc)
+      ActiveType is not compatible with ActiveRecord 4.2.0. Please upgrade to 4.2.1
+      For details see https://github.com/makandra/active_type/issues/31
+    MESSAGE
+  end
+end
+
+
+if defined?(Rails) && defined?(ActiveSupport)
+  # If we are inside Rails, we'll assume active_record will be required anyways
+  # in this case, wait until then, to not mess with ActiveRecord configuration.
+  # (compare https://github.com/rails/rails/issues/23589)
+  ActiveSupport.on_load(:active_record) do
+    load_now.call()
+  end
+else
+  # No Rails.
+  require 'active_record'
+  load_now.call()
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,7 @@ $: << File.join(File.dirname(__FILE__), "/../../lib" )
 require 'active_type'
 
 ActiveRecord::Base.default_timezone = :local
-ActiveRecord::Base.raise_in_transactional_callbacks = true if ActiveRecord::Base.respond_to?(:raise_in_transactional_callbacks)
+ActiveRecord::Base.raise_in_transactional_callbacks = true if ActiveRecord::Base.respond_to?(:raise_in_transactional_callbacks) && ActiveRecord::VERSION::MAJOR < 5
 
 Dir["#{File.dirname(__FILE__)}/support/*.rb"].each {|f| require f}
 Dir["#{File.dirname(__FILE__)}/shared_examples/*.rb"].each {|f| require f}

--- a/spec/support/database.rb
+++ b/spec/support/database.rb
@@ -23,7 +23,8 @@ end
 
 
 connection = ::ActiveRecord::Base.connection
-connection.tables.each do |table|
+tables = connection.respond_to?(:data_sources) ? connection.data_sources : connection.tables
+tables.each do |table|
   connection.drop_table table
 end
 


### PR DESCRIPTION
When active_type is used inside Rails it loads `ActiveRecord::Base` too early. This causes configuration settings set via `Rails.application.config.active_record` (for example `Rails.application.config.belongs_to_required_by_default = true`) set in a Rails initializer (as is default in Rails 5) to be disregarded.

In case `ActiveType` is used without `Rails`, we should load regularly.