### PR TITLE
use autoloading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ tags
 .idea
 tmp
 spec/support/database.yml
+.bundle

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ gemfile:
 before_script:
   - psql -c 'create database active_type_test;' -U postgres
   - mysql -e 'create database IF NOT EXISTS active_type_test;'
-script: bundle exec rspec spec
+script: bundle exec rake spec
 sudo: false
 cache: bundler
 notifications:

--- a/gemfiles/Gemfile.3.2.mysql2
+++ b/gemfiles/Gemfile.3.2.mysql2
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gem 'activerecord', '=3.2.22'
 gem 'rspec', '~> 3.4'
 gem 'mysql2', '= 0.3.17'
+gem 'rake'
 
 gem 'active_type', :path => '..'
 gem 'i18n', '=0.6.11' # 0.7 no longer builds for Ruby 1.8.7

--- a/gemfiles/Gemfile.3.2.mysql2.lock
+++ b/gemfiles/Gemfile.3.2.mysql2.lock
@@ -24,6 +24,7 @@ GEM
     i18n (0.6.11)
     multi_json (1.11.2)
     mysql2 (0.3.17)
+    rake (10.4.2)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
       rspec-expectations (~> 3.4.0)
@@ -47,6 +48,7 @@ DEPENDENCIES
   activerecord (= 3.2.22)
   i18n (= 0.6.11)
   mysql2 (= 0.3.17)
+  rake
   rspec (~> 3.4)
 
 BUNDLED WITH

--- a/gemfiles/Gemfile.3.2.sqlite3
+++ b/gemfiles/Gemfile.3.2.sqlite3
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gem 'activerecord', '=3.2.22'
 gem 'rspec', '~>3.4'
 gem 'sqlite3'
+gem 'rake'
 
 gem 'active_type', :path => '..'
 gem 'i18n', '=0.6.11' # 0.7 no longer builds for Ruby 1.8.7

--- a/gemfiles/Gemfile.3.2.sqlite3.lock
+++ b/gemfiles/Gemfile.3.2.sqlite3.lock
@@ -23,6 +23,7 @@ GEM
     diff-lcs (1.2.5)
     i18n (0.6.11)
     multi_json (1.11.2)
+    rake (10.4.2)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
       rspec-expectations (~> 3.4.0)
@@ -46,6 +47,7 @@ DEPENDENCIES
   active_type!
   activerecord (= 3.2.22)
   i18n (= 0.6.11)
+  rake
   rspec (~> 3.4)
   sqlite3
 

--- a/gemfiles/Gemfile.4.0.sqlite3
+++ b/gemfiles/Gemfile.4.0.sqlite3
@@ -3,5 +3,6 @@ source 'https://rubygems.org'
 gem 'activerecord', '~>4.0.0'
 gem 'rspec', '~>3.4'
 gem 'sqlite3'
+gem 'rake'
 
 gem 'active_type', :path => '..'

--- a/gemfiles/Gemfile.4.0.sqlite3.lock
+++ b/gemfiles/Gemfile.4.0.sqlite3.lock
@@ -28,6 +28,7 @@ GEM
     i18n (0.7.0)
     minitest (4.7.5)
     multi_json (1.11.2)
+    rake (10.4.2)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
       rspec-expectations (~> 3.4.0)
@@ -51,6 +52,7 @@ PLATFORMS
 DEPENDENCIES
   active_type!
   activerecord (~> 4.0.0)
+  rake
   rspec (~> 3.4)
   sqlite3
 

--- a/gemfiles/Gemfile.4.1.sqlite3
+++ b/gemfiles/Gemfile.4.1.sqlite3
@@ -3,5 +3,6 @@ source 'https://rubygems.org'
 gem 'activerecord', '~>4.1.0'
 gem 'rspec', '~>3.4'
 gem 'sqlite3'
+gem 'rake'
 
 gem 'active_type', :path => '..'

--- a/gemfiles/Gemfile.4.1.sqlite3.lock
+++ b/gemfiles/Gemfile.4.1.sqlite3.lock
@@ -26,6 +26,7 @@ GEM
     i18n (0.7.0)
     json (1.8.3)
     minitest (5.8.3)
+    rake (10.4.2)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
       rspec-expectations (~> 3.4.0)
@@ -50,6 +51,7 @@ PLATFORMS
 DEPENDENCIES
   active_type!
   activerecord (~> 4.1.0)
+  rake
   rspec (~> 3.4)
   sqlite3
 

--- a/gemfiles/Gemfile.4.2.1.mysql2
+++ b/gemfiles/Gemfile.4.2.1.mysql2
@@ -3,5 +3,6 @@ source 'https://rubygems.org'
 gem 'activerecord', '~>4.2.1'
 gem 'rspec', '~>3.4'
 gem 'mysql2', '~> 0.3.17'
+gem 'rake'
 
 gem 'active_type', :path => '..'

--- a/gemfiles/Gemfile.4.2.1.mysql2.lock
+++ b/gemfiles/Gemfile.4.2.1.mysql2.lock
@@ -27,6 +27,7 @@ GEM
     json (1.8.3)
     minitest (5.8.3)
     mysql2 (0.3.20)
+    rake (10.4.2)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
       rspec-expectations (~> 3.4.0)
@@ -51,6 +52,7 @@ DEPENDENCIES
   active_type!
   activerecord (~> 4.2.1)
   mysql2 (~> 0.3.17)
+  rake
   rspec (~> 3.4)
 
 BUNDLED WITH

--- a/gemfiles/Gemfile.4.2.1.pg
+++ b/gemfiles/Gemfile.4.2.1.pg
@@ -3,5 +3,6 @@ source 'https://rubygems.org'
 gem 'activerecord', '~>4.2.1'
 gem 'rspec', '~>3.4'
 gem 'pg'
+gem 'rake'
 
 gem 'active_type', :path => '..'

--- a/gemfiles/Gemfile.4.2.1.pg.lock
+++ b/gemfiles/Gemfile.4.2.1.pg.lock
@@ -27,6 +27,7 @@ GEM
     json (1.8.3)
     minitest (5.8.3)
     pg (0.18.4)
+    rake (10.4.2)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
       rspec-expectations (~> 3.4.0)
@@ -51,6 +52,7 @@ DEPENDENCIES
   active_type!
   activerecord (~> 4.2.1)
   pg
+  rake
   rspec (~> 3.4)
 
 BUNDLED WITH

--- a/gemfiles/Gemfile.4.2.1.sqlite3
+++ b/gemfiles/Gemfile.4.2.1.sqlite3
@@ -3,5 +3,6 @@ source 'https://rubygems.org'
 gem 'activerecord', '~>4.2.1'
 gem 'rspec', '~> 3.4'
 gem 'sqlite3'
+gem 'rake'
 
 gem 'active_type', :path => '..'

--- a/gemfiles/Gemfile.4.2.1.sqlite3.lock
+++ b/gemfiles/Gemfile.4.2.1.sqlite3.lock
@@ -26,6 +26,7 @@ GEM
     i18n (0.7.0)
     json (1.8.3)
     minitest (5.8.3)
+    rake (10.4.2)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
       rspec-expectations (~> 3.4.0)
@@ -50,6 +51,7 @@ PLATFORMS
 DEPENDENCIES
   active_type!
   activerecord (~> 4.2.1)
+  rake
   rspec (~> 3.4)
   sqlite3
 

--- a/gemfiles/Gemfile.5.0.0.mysql2
+++ b/gemfiles/Gemfile.5.0.0.mysql2
@@ -3,5 +3,6 @@ source 'https://rubygems.org'
 gem 'activerecord', '~>5.0.0'
 gem 'rspec', '~>3.4'
 gem 'mysql2', '~> 0.3.17'
+gem 'rake'
 
 gem 'active_type', :path => '..'

--- a/gemfiles/Gemfile.5.0.0.mysql2.lock
+++ b/gemfiles/Gemfile.5.0.0.mysql2.lock
@@ -24,6 +24,7 @@ GEM
     i18n (0.7.0)
     minitest (5.9.0)
     mysql2 (0.3.21)
+    rake (10.4.2)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
@@ -48,6 +49,7 @@ DEPENDENCIES
   active_type!
   activerecord (~> 5.0.0)
   mysql2 (~> 0.3.17)
+  rake
   rspec (~> 3.4)
 
 BUNDLED WITH

--- a/gemfiles/Gemfile.5.0.0.pg
+++ b/gemfiles/Gemfile.5.0.0.pg
@@ -3,5 +3,6 @@ source 'https://rubygems.org'
 gem 'activerecord', '~>5.0.0'
 gem 'rspec', '~>3.4'
 gem 'pg'
+gem 'rake'
 
 gem 'active_type', :path => '..'

--- a/gemfiles/Gemfile.5.0.0.pg.lock
+++ b/gemfiles/Gemfile.5.0.0.pg.lock
@@ -24,6 +24,7 @@ GEM
     i18n (0.7.0)
     minitest (5.9.0)
     pg (0.18.4)
+    rake (10.4.2)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
@@ -48,6 +49,7 @@ DEPENDENCIES
   active_type!
   activerecord (~> 5.0.0)
   pg
+  rake
   rspec (~> 3.4)
 
 BUNDLED WITH

--- a/gemfiles/Gemfile.5.0.0.sqlite3
+++ b/gemfiles/Gemfile.5.0.0.sqlite3
@@ -3,5 +3,6 @@ source 'https://rubygems.org'
 gem 'activerecord', '~>5.0.0'
 gem 'rspec', '~> 3.4'
 gem 'sqlite3'
+gem 'rake'
 
 gem 'active_type', :path => '..'

--- a/gemfiles/Gemfile.5.0.0.sqlite3.lock
+++ b/gemfiles/Gemfile.5.0.0.sqlite3.lock
@@ -23,6 +23,7 @@ GEM
     diff-lcs (1.2.5)
     i18n (0.7.0)
     minitest (5.9.0)
+    rake (10.4.2)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
@@ -47,6 +48,7 @@ PLATFORMS
 DEPENDENCIES
   active_type!
   activerecord (~> 5.0.0)
+  rake
   rspec (~> 3.4)
   sqlite3
 

--- a/lib/active_type.rb
+++ b/lib/active_type.rb
@@ -2,30 +2,19 @@
 
 require 'active_type/version'
 
+require 'active_record'
 
-load_now = proc do
-  require 'active_type/util'
-  require 'active_type/record'
-  require 'active_type/object'
-
-  if ActiveRecord::VERSION::STRING == '4.2.0'
-    raise(<<-MESSAGE.strip_heredoc)
-      ActiveType is not compatible with ActiveRecord 4.2.0. Please upgrade to 4.2.1
-      For details see https://github.com/makandra/active_type/issues/31
-    MESSAGE
-  end
+if ActiveRecord::VERSION::STRING == '4.2.0'
+  raise(<<-MESSAGE.strip_heredoc)
+    ActiveType is not compatible with ActiveRecord 4.2.0. Please upgrade to 4.2.1
+    For details see https://github.com/makandra/active_type/issues/31
+  MESSAGE
 end
 
+module ActiveType
+  extend ActiveSupport::Autoload
 
-if defined?(Rails) && defined?(ActiveSupport)
-  # If we are inside Rails, we'll assume active_record will be required anyways
-  # in this case, wait until then, to not mess with ActiveRecord configuration.
-  # (compare https://github.com/rails/rails/issues/23589)
-  ActiveSupport.on_load(:active_record) do
-    load_now.call()
-  end
-else
-  # No Rails.
-  require 'active_record'
-  load_now.call()
+  autoload :Object
+  autoload :Record
+  autoload :Util
 end

--- a/spec/isolated/load_without_active_record_use_spec.rb
+++ b/spec/isolated/load_without_active_record_use_spec.rb
@@ -1,0 +1,14 @@
+# encoding: utf-8
+
+require 'isolated_spec_helper'
+
+RSpec.describe 'ActiveType', type: :isolated do
+
+  it 'can be used without explicitly using ActiveRecord::Base first' do
+    expect {
+      require 'active_type'
+      ActiveType::Object
+    }.not_to raise_error
+  end
+
+end

--- a/spec/isolated/load_without_active_record_use_within_rails_spec.rb
+++ b/spec/isolated/load_without_active_record_use_within_rails_spec.rb
@@ -1,0 +1,15 @@
+# encoding: utf-8
+
+require 'isolated_spec_helper'
+
+RSpec.describe 'ActiveType', type: :isolated do
+
+  it 'can be used in a Rails app without explicitly using ActiveRecord::Base first (see issue #75)' do
+    expect {
+      fake_rails
+      require 'active_type'
+      ActiveType::Object
+    }.not_to raise_error
+  end
+
+end

--- a/spec/isolated/require_does_not_trigger_ar_load_spec.rb
+++ b/spec/isolated/require_does_not_trigger_ar_load_spec.rb
@@ -1,0 +1,17 @@
+# encoding: utf-8
+
+require 'isolated_spec_helper'
+
+RSpec.describe 'ActiveType', type: :isolated do
+
+  it 'does not trigger active_record load-hook on require, since this messes up AR configuration via Rails initializers (see issue #72)' do
+    fake_rails
+    loaded = false
+    ActiveSupport.on_load(:active_record) do
+      loaded = true
+    end
+    require 'active_type'
+    expect(loaded).to eq false
+  end
+
+end

--- a/spec/isolated_spec_helper.rb
+++ b/spec/isolated_spec_helper.rb
@@ -1,0 +1,29 @@
+# encoding: utf-8
+
+$: << File.join(File.dirname(__FILE__), "/../../lib" )
+
+module FakeRailsHelper
+  def fake_rails
+    require 'active_support'
+    require 'active_record'
+    eval <<-RUBY
+      module ::Rails
+        def self.env
+          'test'
+        end
+      end
+    RUBY
+  end
+end
+
+RSpec.configure do |config|
+  config.include FakeRailsHelper
+
+  config.around(:example, type: :isolated) do |example|
+    if defined?(ActiveType::Object) || defined?(ActiveType::Record)
+      skip('can only run isolated')
+    else
+      example.run
+    end
+  end
+end


### PR DESCRIPTION
#73 introduced a regression as demonstrated in #75.

Instead of using `ActiveRecord`'s load hook, just use regular Ruby autoloading.

I've added specs to test #73 and these changes, which have to run in isolation from other specs. These will run when using `rake spec` or `rake all:spec` or travis.