### PR TITLE
wrap activerecord call in a with_connection block so we don't leak a db connection

### DIFF
--- a/lib/active_type/type_caster.rb
+++ b/lib/active_type/type_caster.rb
@@ -107,7 +107,9 @@ module ActiveType
           if type.respond_to?(:cast)
             type
           else
-            ActiveRecord::Type.lookup(type)
+            ActiveRecord::Base.connection_pool.with_connection{
+              ActiveRecord::Type.lookup(type)
+            }
           end
         rescue ::ArgumentError => e
           ActiveRecord::Type::Value.new


### PR DESCRIPTION
At least when running in production under passenger, without this, our app leaks a database connection for each passenger instance.  The connection is only used during initialization of the stack and then sits idle forever.