### PR TITLE
make ActiveType::Object work without db connection

### DIFF
--- a/gemfiles/Gemfile.3.2.mysql2.lock
+++ b/gemfiles/Gemfile.3.2.mysql2.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_type (0.6.4)
+    active_type (0.7.0)
       activerecord (>= 3.2)
 
 GEM

--- a/gemfiles/Gemfile.3.2.sqlite3.lock
+++ b/gemfiles/Gemfile.3.2.sqlite3.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_type (0.6.4)
+    active_type (0.7.0)
       activerecord (>= 3.2)
 
 GEM

--- a/gemfiles/Gemfile.4.0.sqlite3.lock
+++ b/gemfiles/Gemfile.4.0.sqlite3.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_type (0.6.4)
+    active_type (0.7.0)
       activerecord (>= 3.2)
 
 GEM

--- a/gemfiles/Gemfile.4.1.sqlite3.lock
+++ b/gemfiles/Gemfile.4.1.sqlite3.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_type (0.6.4)
+    active_type (0.7.0)
       activerecord (>= 3.2)
 
 GEM

--- a/gemfiles/Gemfile.4.2.1.mysql2.lock
+++ b/gemfiles/Gemfile.4.2.1.mysql2.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_type (0.6.4)
+    active_type (0.7.0)
       activerecord (>= 3.2)
 
 GEM

--- a/gemfiles/Gemfile.4.2.1.pg.lock
+++ b/gemfiles/Gemfile.4.2.1.pg.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_type (0.6.4)
+    active_type (0.7.0)
       activerecord (>= 3.2)
 
 GEM

--- a/gemfiles/Gemfile.4.2.1.sqlite3.lock
+++ b/gemfiles/Gemfile.4.2.1.sqlite3.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_type (0.6.4)
+    active_type (0.7.0)
       activerecord (>= 3.2)
 
 GEM

--- a/gemfiles/Gemfile.5.0.0.mysql2.lock
+++ b/gemfiles/Gemfile.5.0.0.mysql2.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_type (0.6.4)
+    active_type (0.7.0)
       activerecord (>= 3.2)
 
 GEM

--- a/gemfiles/Gemfile.5.0.0.pg.lock
+++ b/gemfiles/Gemfile.5.0.0.pg.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_type (0.6.4)
+    active_type (0.7.0)
       activerecord (>= 3.2)
 
 GEM

--- a/gemfiles/Gemfile.5.0.0.sqlite3.lock
+++ b/gemfiles/Gemfile.5.0.0.sqlite3.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_type (0.6.4)
+    active_type (0.7.0)
       activerecord (>= 3.2)
 
 GEM

--- a/lib/active_type/nested_attributes/association.rb
+++ b/lib/active_type/nested_attributes/association.rb
@@ -111,7 +111,7 @@ module ActiveType
       end
 
       def truthy?(value)
-        @boolean_type_caster ||= TypeCaster.get(:boolean, @owner.connection)
+        @boolean_type_caster ||= TypeCaster.get(:boolean)
         @boolean_type_caster.type_cast_from_user(value)
       end
 

--- a/lib/active_type/virtual_attributes.rb
+++ b/lib/active_type/virtual_attributes.rb
@@ -46,7 +46,7 @@ module ActiveType
       private
 
       def add_virtual_column(name, type, options)
-        type_caster = TypeCaster.get(type, @owner.connection)
+        type_caster = TypeCaster.get(type)
         column = VirtualColumn.new(name, type_caster, options.slice(:default))
         @owner.virtual_columns_hash = @owner.virtual_columns_hash.merge(name.to_s => column)
       end

--- a/spec/isolated/active_object_does_not_need_db_spec.rb
+++ b/spec/isolated/active_object_does_not_need_db_spec.rb
@@ -1,0 +1,15 @@
+require 'isolated_spec_helper'
+
+RSpec.describe 'ActiveType::Object', type: :isolated do
+
+  it 'does not need a database connection' do
+    require 'active_type'
+    expect {
+      klass = Class.new(ActiveType::Object) do
+        attribute :foo, :integer
+      end
+      expect(klass.new(foo: '15').foo).to eq 15
+    }.not_to raise_error
+  end
+
+end


### PR DESCRIPTION
I've tried to change the type casting logic to not require a database connection. This is probably a breaking change for Rails 4 and 5, since it means no support for database-specific types, but I never actually used this. I don't feel this has been a useful (or in the case of `ActiveType::Object` expected) feature, so I think this should be worth it?
@triskweline: Do you have a opinion on this?