### PR TITLE
Support uuid for nest association

### DIFF
--- a/lib/active_type/nested_attributes/nests_many_association.rb
+++ b/lib/active_type/nested_attributes/nests_many_association.rb
@@ -31,7 +31,7 @@ module ActiveType
           destroy = truthy?(attributes.delete(:_destroy)) && @allow_destroy
 
           if id = attributes.delete(:id)
-            child = fetch_child(parent, id.to_i)
+            child = fetch_child(parent, id)
             if destroy
               child.mark_for_destruction
             else

--- a/lib/active_type/nested_attributes/nests_one_association.rb
+++ b/lib/active_type/nested_attributes/nests_one_association.rb
@@ -17,9 +17,9 @@ module ActiveType
         destroy = truthy?(attributes.delete(:_destroy)) && @allow_destroy
 
         if id = attributes.delete(:id)
-          assigned_child ||= fetch_child(parent, id.to_i)
+          assigned_child ||= fetch_child(parent, id)
           if assigned_child
-            if assigned_child.id == id.to_i
+            if assigned_child.id == id
               assigned_child.attributes = attributes
             else
               raise AssignmentError, "child record '#{@target_name}' did not match id '#{id}'"

--- a/spec/support/database.rb
+++ b/spec/support/database.rb
@@ -42,6 +42,11 @@ ActiveRecord::Migration.class_eval do
     t.integer :record_id
   end
 
+  create_table :uuid_records, id: false do |t|
+    t.string :id, primary_key: true
+    t.string :persisted_string
+  end
+
   create_table :sti_records do |t|
     t.string :persisted_string
     t.string :type


### PR DESCRIPTION
In Rails 5, it is convenient to set uuid as the id for models. However, the current implementation of this gem assumes that the type of id will always be an integer. In my opinion, I think that using string instead of integer will be more general, so I create this PR to show my suggested changes, hoping that we can have some discuss on this if necessary :)