### PR TITLE
cast failed when database timezone is UTC

### DIFF
--- a/lib/active_type/type_caster.rb
+++ b/lib/active_type/type_caster.rb
@@ -30,7 +30,11 @@ module ActiveType
       when :timestamp, :datetime
         time = native_type_cast_from_user(value)
         if time && ActiveRecord::Base.time_zone_aware_attributes
-          time = ActiveSupport::TimeWithZone.new(nil, Time.zone, time)
+          if time.zone == 'UTC'
+            time = ActiveSupport::TimeWithZone.new(time, Time.zone)
+          else
+            time = ActiveSupport::TimeWithZone.new(nil, Time.zone, time)
+          end
         end
         time
       else


### PR DESCRIPTION
database timezone : UTC
local timezone: JST

```
class Foo < ActiveType::Object
  attribute :bar, :datetime
end

foo = Foo.new
foo.bar = "2017-07-20T15:00:00.000+09:00"
p foo.bar # Thu, 20 Jul 2017 06:00:00 JST +09:00 ← failed
```

active_type: 0.7.0
rails: 5.1.1