### PR TITLE
Fix/child match

### DIFF
--- a/lib/active_type/nested_attributes/nests_one_association.rb
+++ b/lib/active_type/nested_attributes/nests_one_association.rb
@@ -19,6 +19,7 @@ module ActiveType
         if id = attributes.delete(:id)
           assigned_child ||= fetch_child(parent, id)
           if assigned_child
+            id = id.to_i if assigned_child.id.is_a?(Fixnum)
             if assigned_child.id == id
               assigned_child.attributes = attributes
             else

--- a/lib/active_type/nested_attributes/nests_one_association.rb
+++ b/lib/active_type/nested_attributes/nests_one_association.rb
@@ -19,8 +19,8 @@ module ActiveType
         if id = attributes.delete(:id)
           assigned_child ||= fetch_child(parent, id)
           if assigned_child
-            id = id.to_i if assigned_child.id.is_a?(Fixnum)
-            if assigned_child.id == id
+            assigned_child.id = id
+            if assigned_child.id == assigned_child.id_was
               assigned_child.attributes = attributes
             else
               raise AssignmentError, "child record '#{@target_name}' did not match id '#{id}'"

--- a/spec/active_type/nested_attributes_spec.rb
+++ b/spec/active_type/nested_attributes_spec.rb
@@ -557,6 +557,14 @@ describe "ActiveType::Object" do
         expect(subject.record).to eq(nil)
       end
 
+      it 'do not raises an error when the id is a string of an existent record' do
+        expect do
+          subject.record = record
+          subject.record_attributes = { :id => "#{record.id}", :persisted_string => "updated string" }
+          should_assign_and_persist("updated string")
+        end.not_to raise_error
+      end
+
       it 'raises an error if the assigned record does not match the id' do
         expect do
           subject.record = NestedAttributesSpec::Record.create!


### PR DESCRIPTION
Version [0.7.3](https://github.com/makandra/active_type/blob/master/CHANGELOG.md#073-2017-08-16) introduced support to non-integer primary keys, this breaks the common idiom in controllers for integer primary keys:

`subject.record_attributes = subject_params['record_attributes']`

This happens, because the params attributes are all strings, but when the subject.record is constructed their values are casted to the database types, making the comparison in https://github.com/makandra/active_type/blob/master/lib/active_type/nested_attributes/nests_one_association.rb#L22 fail, since an integer gets compared with an string.

I don't like the idiom of my fix, so if anyone has a better idea, feel free to suggest.

Thanks!