### PR TITLE
Don't add type conditions when inheriting a base STI type

### DIFF
--- a/lib/active_type/record_extension/inheritance.rb
+++ b/lib/active_type/record_extension/inheritance.rb
@@ -82,6 +82,10 @@ module ActiveType
             end
             #### our code starts here
             if self <= subclass
+              # If we are a derived class of the real class, replace it with ourselves
+              subclass = self
+            elsif extended_record_base_class >= subclass
+              # If the class is a subclass of our parent, replace it with ourselves to avoid the below error
               subclass = self
             end
             #### our code ends here

--- a/lib/active_type/record_extension/inheritance.rb
+++ b/lib/active_type/record_extension/inheritance.rb
@@ -35,6 +35,10 @@ module ActiveType
           extended_record_base_class.sti_name
         end
 
+        def descends_from_active_record?
+          extended_record_base_class.descends_from_active_record?
+        end
+
         def has_many(name, *args, &extension)
           super(name, *Inheritance.add_foreign_key_option(extended_record_base_class, *args), &extension)
         end

--- a/spec/active_type/extended_record/single_table_inheritance_spec.rb
+++ b/spec/active_type/extended_record/single_table_inheritance_spec.rb
@@ -15,6 +15,9 @@ module STISpec
   class ExtendedExtendedChild < ActiveType::Record[ExtendedChild]
   end
 
+  class ExtendedParent < ActiveType::Record[Parent]
+  end
+
 end
 
 
@@ -32,6 +35,7 @@ describe 'ActiveType::Record[STIModel]' do
     end
 
     it 'it does not require an STI type condition' do
+      expect(STISpec::ExtendedParent.descends_from_active_record?).to eq(true)
       expect(STISpec::ExtendedChild.descends_from_active_record?).to eq(false)
       expect(STISpec::ExtendedExtendedChild.descends_from_active_record?).to eq(false)
     end
@@ -43,6 +47,10 @@ describe 'ActiveType::Record[STIModel]' do
 
     it 'can save as base and load as active type record' do
       should_save_and_load(STISpec::Child, STISpec::ExtendedChild)
+    end
+
+    it 'can save as base and load as active type parent record' do
+      should_save_and_load(STISpec::Child, STISpec::ExtendedParent)
     end
 
     it 'can save as active type and load as base record' do

--- a/spec/active_type/extended_record/single_table_inheritance_spec.rb
+++ b/spec/active_type/extended_record/single_table_inheritance_spec.rb
@@ -31,6 +31,11 @@ describe 'ActiveType::Record[STIModel]' do
       expect(reloaded_child).to be_a(load_as)
     end
 
+    it 'it does not require an STI type condition' do
+      expect(STISpec::ExtendedChild.descends_from_active_record?).to eq(false)
+      expect(STISpec::ExtendedExtendedChild.descends_from_active_record?).to eq(false)
+    end
+
     it 'can save and load the active type record' do
 
       should_save_and_load(STISpec::ExtendedChild, STISpec::ExtendedChild)


### PR DESCRIPTION
If we don't override descends_from_active_record? , then SQL queries will include a

    WHERE type in ('DerivedClassName')

which is not what we want