### PR TITLE
Override i18n_key on ActiveRecord-derived classes

### DIFF
--- a/lib/active_type/record_extension/inheritance.rb
+++ b/lib/active_type/record_extension/inheritance.rb
@@ -28,7 +28,24 @@ module ActiveType
       module ClassMethods
 
         def model_name
-          extended_record_base_class.model_name
+          @_model_name ||= begin
+            if name
+              # Namespace detection copied from ActiveModel::Naming
+              namespace = extended_record_base_class.parents.detect do |n|
+                n.respond_to?(:use_relative_model_naming?) && n.use_relative_model_naming?
+              end
+              # We create a Name object, with the parent class name, but self as the @klass reference
+              # This way lookup_ancestors is invoked on the right class instead of the extended_record_base_class
+              dup_model_name = ActiveModel::Name.new(self, namespace, extended_record_base_class.name)
+              key = name.underscore
+              # We fake the `i18n_key` to lookup on the derived class key
+              # We keep the others the same to preserve parameter and route names
+              dup_model_name.define_singleton_method(:i18n_key) { key }
+              dup_model_name
+            else # name is nil for the anonymous intermediate class
+              extended_record_base_class.model_name
+            end
+          end
         end
 
         def sti_name

--- a/spec/active_type/record_extension_spec.rb
+++ b/spec/active_type/record_extension_spec.rb
@@ -137,6 +137,10 @@ describe "class ... < ActiveType::Record[ActiveRecord::Base]" do
     expect(subject.class.model_name.singular).to eq(RecordExtensionSpec::Record.model_name.singular)
   end
 
+  it 'has a different i18n_key than the base class' do
+    expect(subject.class.model_name.i18n_key).to eq(RecordExtensionSpec::InheritingFromExtendedRecord.name.underscore)
+  end
+
   describe '#attributes' do
 
     it 'returns a hash of virtual and persisted attributes' do
@@ -256,4 +260,45 @@ describe "ActiveType::Record[ActiveType::Record]" do
     end
   end
 
+end
+
+describe 'i18n' do
+
+  around :each do |test|
+    begin
+      orig_backend = I18n.backend
+      I18n.backend = I18n::Backend::KeyValue.new({})
+      test.run
+    ensure
+      I18n.backend = orig_backend
+    end
+  end
+
+  describe 'translation of model name' do
+
+    it 'has its own I18n key' do
+      I18n.backend.store_translations(:en, activerecord: { models: { 'record_extension_spec/extended_record': 'ExtendedRecord translation' } })
+      expect(RecordExtensionSpec::ExtendedRecord.model_name.human).to eq('ExtendedRecord translation')
+    end
+
+    it 'falls back to the I18n key of the base class if does not have its own I18n key' do
+      I18n.backend.store_translations(:en, activerecord: { models: { 'record_extension_spec/record': 'BaseRecord translation' } })
+      expect(RecordExtensionSpec::ExtendedRecord.model_name.human).to eq('BaseRecord translation')
+    end
+
+  end
+
+  describe 'translation of attribute name' do
+
+    it 'has its own I18n key' do
+      I18n.backend.store_translations(:en, activerecord: { attributes: { 'record_extension_spec/extended_record': { persisted_string: 'ExtendedRecord translation' } } })
+      expect(RecordExtensionSpec::ExtendedRecord.human_attribute_name(:persisted_string)).to eq('ExtendedRecord translation')
+    end
+
+    it 'falls back to the I18n key of the base class if does not have its own I18n key' do
+      I18n.backend.store_translations(:en, activerecord: { attributes: { 'record_extension_spec/record': { persisted_string: 'BaseRecord translation' } } })
+      expect(RecordExtensionSpec::ExtendedRecord.human_attribute_name(:persisted_string)).to eq('BaseRecord translation')
+    end
+
+  end
 end


### PR DESCRIPTION
This allows creating translations for the derived classes themselves instead of polluting
the base class translations

Fixes: #115