### PR TITLE
Fix change_association with polymorphic association

### DIFF
--- a/lib/active_type/record_extension/inheritance.rb
+++ b/lib/active_type/record_extension/inheritance.rb
@@ -15,7 +15,7 @@ module ActiveType
           options = scope
           scope = nil
         end
-        unless options[:foreign_key]
+        unless options[:foreign_key] || options[:as]
           options = options.merge(foreign_key: extended_record_base_class.name.foreign_key)
         end
         if ActiveRecord::VERSION::MAJOR > 3

--- a/spec/support/database.rb
+++ b/spec/support/database.rb
@@ -17,6 +17,11 @@ database.rewrite_schema! do
     t.boolean :nice
   end
 
+  create_table :pictures do |t|
+    t.integer :imageable_id
+    t.string :imageable_type
+  end
+
   create_table :uuid_records, id: false do |t|
     t.string :id, primary_key: true, limit: 100
     t.string :persisted_string


### PR DESCRIPTION
When using `change_assocation` with a [polymorphic association](https://guides.rubyonrails.org/association_basics.html#polymorphic-associations), active type is overwriting the association's `foreign_key`, causing "unknown column" errors.

Fix this by skipping the foreign key override when using a polymorphic association (`as: ...`).