### PR TITLE
Fix nests_one association record building

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased changes
+* Fixed: `nests_one` association record building used empty hash instead of passed in attributes. Credit to @chriscz.
 
 ## 1.3.1 (2020-03-31)
 * Fixed: Avoid #change_association breaking for polymorphic associations. Thanks to @lucthev.

--- a/lib/active_type/nested_attributes/nests_one_association.rb
+++ b/lib/active_type/nested_attributes/nests_one_association.rb
@@ -30,8 +30,11 @@ module ActiveType
             end
           end
         elsif !destroy
-          assigned_child ||= add_child(parent, build_child(parent, {}))
-          assigned_child.attributes = attributes
+          if assigned_child
+            assigned_child.attributes = attributes
+          else
+            add_child(parent, build_child(parent, attributes))
+          end
         end
       end
 


### PR DESCRIPTION
New nests_one records are now built with the passed in attributes instead of an empty hash. Fixes #119 