### PR TITLE
Implement YAML serialization

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,6 +108,7 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
       - name: Install database client
         run: |
+          sudo apt-get update
           sudo apt-get install -y mysql-client libmariadbclient-dev
       - name: Bundle
         run: |

--- a/lib/active_type/virtual_attributes.rb
+++ b/lib/active_type/virtual_attributes.rb
@@ -8,6 +8,23 @@ module ActiveType
 
   module VirtualAttributes
 
+    module Serialization
+      extend ActiveSupport::Concern
+
+      def init_with(coder)
+        if coder['virtual_attributes'].present?
+          @virtual_attributes = coder['virtual_attributes']
+        end
+        super(coder)
+      end
+
+      def encode_with(coder)
+        coder['virtual_attributes'] = @virtual_attributes
+        coder['active_type_yaml_version'] = 1
+        super(coder)
+      end
+    end
+
     class VirtualColumn
 
       def initialize(name, type_caster, options)
@@ -110,10 +127,10 @@ module ActiveType
       result
     end
 
-
     extend ActiveSupport::Concern
 
     included do
+      include ActiveType::VirtualAttributes::Serialization
       class_attribute :virtual_columns_hash
       self.virtual_columns_hash = {}
 

--- a/spec/integration/sign_in_spec.rb
+++ b/spec/integration/sign_in_spec.rb
@@ -74,6 +74,10 @@ describe SignInSpec::SignIn do
       subject.save
     end
 
+    context 'before save' do
+      it_should_behave_like 'an instance supporting serialization'
+    end
+
   end
 
   describe 'with valid credentials' do
@@ -94,6 +98,15 @@ describe SignInSpec::SignIn do
     it 'sets the session' do
       expect(subject).to receive :set_session
       subject.save
+    end
+
+    context 'before save' do
+      it_should_behave_like 'an instance supporting serialization'
+    end
+
+    context 'after save' do
+      before { subject.save }
+      it_should_behave_like 'an instance supporting serialization'
     end
 
   end

--- a/spec/integration/sign_up_spec.rb
+++ b/spec/integration/sign_up_spec.rb
@@ -75,6 +75,10 @@ describe SignUpSpec::SignUp do
       subject.save
     end
 
+    context 'before save' do
+      it_should_behave_like 'an instance supporting serialization'
+    end
+
   end
 
   context 'with valid data' do
@@ -96,6 +100,14 @@ describe SignUpSpec::SignUp do
       subject.save
     end
 
+    context 'before save' do
+      it_should_behave_like 'an instance supporting serialization'
+    end
+
+    context 'after save' do
+      before { subject.save }
+      it_should_behave_like 'an instance supporting serialization'
+    end
   end
 
 

--- a/spec/shared_examples/serialization.rb
+++ b/spec/shared_examples/serialization.rb
@@ -1,0 +1,11 @@
+shared_examples_for "an instance supporting serialization" do
+  it 'serializes correctly with to_yaml' do
+    deserialized = YAML.load(subject.to_yaml)
+
+    subject.attributes.each do |attr, value|
+      expect(deserialized.send(attr)).to eq(value)
+    end
+
+    expect(deserialized.new_record?).to eq(subject.new_record?)
+  end
+end

--- a/spec/shared_examples/serialization.rb
+++ b/spec/shared_examples/serialization.rb
@@ -5,7 +5,5 @@ shared_examples_for "an instance supporting serialization" do
     subject.attributes.each do |attr, value|
       expect(deserialized.send(attr)).to eq(value)
     end
-
-    expect(deserialized.new_record?).to eq(subject.new_record?)
   end
 end


### PR DESCRIPTION
This implements YAML serialization in a way that's (hopefully) completely compatible with ActiveRecord's current and previous implementation. Closes #127 