### PR TITLE
Change inheritance use of keyword args for ruby 3 compatability

### DIFF
--- a/lib/active_type/record_extension/inheritance.rb
+++ b/lib/active_type/record_extension/inheritance.rb
@@ -68,14 +68,22 @@ module ActiveType
           merged_opts = Inheritance.add_foreign_key_option(extended_record_base_class, *args)
           options = merged_opts[-1]
           scope = merged_opts.first == options ? nil : merged_opts.first
-          super(name, scope, **options, &extension)
+          if ActiveRecord::VERSION::MAJOR > 3
+            super(name, scope, **options, &extension)
+          else
+            super(name, **options, &extension)
+          end
         end
 
         def has_one(name, *args, &extension)
           merged_opts = Inheritance.add_foreign_key_option(extended_record_base_class, *args)
           options = merged_opts[-1]
           scope = merged_opts.first == options ? nil : merged_opts.first
-          super(name, scope, **options, &extension)
+          if ActiveRecord::VERSION::MAJOR > 3
+            super(name, scope, **options, &extension)
+          else
+            super(name, **options, &extension)
+          end
         end
 
         private

--- a/lib/active_type/record_extension/inheritance.rb
+++ b/lib/active_type/record_extension/inheritance.rb
@@ -65,11 +65,17 @@ module ActiveType
         end
 
         def has_many(name, *args, &extension)
-          super(name, *Inheritance.add_foreign_key_option(extended_record_base_class, *args), &extension)
+          merged_opts = Inheritance.add_foreign_key_option(extended_record_base_class, *args)
+          options = merged_opts[-1]
+          scope = merged_opts.first == options ? nil : merged_opts.first
+          super(name, scope, **options, &extension)
         end
 
         def has_one(name, *args, &extension)
-          super(name, *Inheritance.add_foreign_key_option(extended_record_base_class, *args), &extension)
+          merged_opts = Inheritance.add_foreign_key_option(extended_record_base_class, *args)
+          options = merged_opts[-1]
+          scope = merged_opts.first == options ? nil : merged_opts.first
+          super(name, scope, **options, &extension)
         end
 
         private


### PR DESCRIPTION
I believe due to [Ruby 3 changes around keyword arguments](https://rubyreferences.github.io/rubychanges/3.0.html#keyword-arguments-are-now-fully-separated-from-positional-arguments), the overridden functionality of `has_many` and `has_one` no longer works as expected. This causes #136 and this change has fixed the issue for me.

It's not very "railsy", so let me know if it needs a refactor.