### PR TITLE
use mariadb-client instead of mysql-client in tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Install database client
         run: |
           sudo apt-get update
-          sudo apt-get install -y mysql-client libmariadbclient-dev
+          sudo apt-get install -y mariadb-client libmariadbclient-dev
       - name: Bundle
         run: |
           gem install bundler:2.0.2


### PR DESCRIPTION
Attempt to fix mysql tests