### PR TITLE
Fix a ruby warning due to redundant regex pattern

### DIFF
--- a/lib/active_type/virtual_attributes.rb
+++ b/lib/active_type/virtual_attributes.rb
@@ -112,7 +112,7 @@ module ActiveType
       end
 
       def validate_attribute_name!(name)
-        unless name.to_s =~ /\A[A-z0-9_]*\z/
+        unless name.to_s =~ /\A[A-z0-9]*\z/
           raise InvalidAttributeNameError.new("'#{name}' is not a valid name for a virtual attribute")
         end
       end

--- a/lib/active_type/virtual_attributes.rb
+++ b/lib/active_type/virtual_attributes.rb
@@ -112,7 +112,7 @@ module ActiveType
       end
 
       def validate_attribute_name!(name)
-        unless name.to_s =~ /\A[A-z0-9]*\z/
+        unless name.to_s =~ /\A[A-Za-z0-9_]*\z/
           raise InvalidAttributeNameError.new("'#{name}' is not a valid name for a virtual attribute")
         end
       end


### PR DESCRIPTION
This fixes the following ruby warning:

```
lib/active_type/virtual_attributes.rb:115:warning: character class has duplicated range: /\A[A-z0-9_]*\z/
```

This fix adapts the regex in a way that does not alter its matching pattern. However, while the pattern `[A-z]` includes all the characters from the alphabet, lower and upper case, it also includes the characters `[`, `\`, `]`, and `^` (among `_`, which is the point of this issue). If this is not desired, the pattern should be changed to `/\A[A-Za-z0-9_]*\z/` instead, as it would be more specific and does not allow any additional characters.

Thanks for considering this PR 👍 