### PR TITLE
Fix aliassing ar_attribute method

### DIFF
--- a/lib/active_type/virtual_attributes.rb
+++ b/lib/active_type/virtual_attributes.rb
@@ -137,6 +137,7 @@ module ActiveType
       class << self
         if method_defined?(:attribute)
           alias_method :ar_attribute, :attribute
+          alias_method :attribute, :at_attribute
         end
       end
     end
@@ -323,7 +324,7 @@ module ActiveType
         end
       end
 
-      def attribute(name, *args)
+      def at_attribute(name, *args)
         options = args.extract_options!
         type = args.first
 


### PR DESCRIPTION
In `lib/active_type/virtual_attributes.rb`, an alias is created so that the original ActiveRecord method `attribute` still can be used:

```ruby
class << self
  if method_defined?(:attribute)
    alias_method :ar_attribute, :attribute
  end
end
```

The problem is that, since this is an `ActiveSupport::Concern`, the `ClassMethods`-Module which contains the new `attribute` method is mixed in **before** the aliassing happens. This effectively aliases the ActiveType `attribute` to itself - at least with Ruby 3 and Rails 7.

This PR attempts to fix this by renaming the overriding method `attribute` to `at_attribute` and performing a second alias operation.

Many thanks for having a look at this 👍 🎆 