### PR TITLE
Support attributes that are also a keyword

### DIFF
--- a/lib/active_type/virtual_attributes.rb
+++ b/lib/active_type/virtual_attributes.rb
@@ -100,7 +100,7 @@ module ActiveType
 
         @module.module_eval <<-BODY, __FILE__, __LINE__ + 1
           def #{name}_changed?
-            #{name} != virtual_attributes_were["#{name}"]
+            self.#{name} != virtual_attributes_were["#{name}"]
           end
         BODY
 


### PR DESCRIPTION
Fix an error when an attribute name is a keyword, e.g. `alias`, `end`, …

Given
```ruby
attribute :alias, :string
```

I got an error
```
SyntaxError:
  active_type-2.2.0/lib/active_type/virtual_attributes.rb:103: syntax error, unexpected '[', expecting `end'
  ...ias != virtual_attributes_were["alias"]
  ```
The patch adds a prefix `self` that fixes the syntax error in generated code.
```ruby
self.alias != virtual_attributes_were["alias"]
```

