### PR TITLE
refactor 'cast_record' to use 'attr_accessor' from ActiveRecord::Base

### DIFF
--- a/lib/active_type/util.rb
+++ b/lib/active_type/util.rb
@@ -1,5 +1,6 @@
 require 'active_type/not_castable_error'
 require 'active_type/util/unmutable_attributes'
+require 'active_type/util/active_record'
 
 module ActiveType
   module Util
@@ -59,6 +60,9 @@ module ActiveType
         if !force
           make_record_unusable(record)
         end
+
+        casted.after_cast(record)
+        
         casted
       end
     end

--- a/lib/active_type/util/active_record.rb
+++ b/lib/active_type/util/active_record.rb
@@ -1,0 +1,9 @@
+module ActiveType
+	module Util
+
+		class ActiveRecord::Base
+			
+			def after_cast(record) end
+		end
+	end
+end

--- a/spec/active_type/util_spec.rb
+++ b/spec/active_type/util_spec.rb
@@ -5,6 +5,13 @@ module UtilSpec
   class BaseRecord < ActiveRecord::Base
     self.table_name = 'records'
     has_many :associated_records
+
+    attr_accessor :persisted_attribute
+
+    def after_cast(record)
+      @persisted_attribute = record.persisted_attribute
+    end
+
   end
 
   class ExtendedRecord < ActiveType::Record[BaseRecord]
@@ -77,6 +84,18 @@ describe ActiveType::Util do
         expect(extended_record.id).to be_present
         expect(extended_record.id).to eq(base_record.id)
         expect(extended_record.persisted_string).to eq('foo')
+      end
+
+      it 'casts a base record persist attr_reader' do
+        base_record = UtilSpec::BaseRecord.create!(:persisted_string => 'foo')
+        base_record.persisted_attribute = 'bar'
+        extended_record = ActiveType::Util.cast(base_record, UtilSpec::BaseRecord)
+        expect(extended_record).to be_a(UtilSpec::BaseRecord)
+        expect(extended_record).to be_persisted
+        expect(extended_record.id).to be_present
+        expect(extended_record.id).to eq(base_record.id)
+        expect(extended_record.persisted_string).to eq('foo')
+        expect(extended_record.persisted_attribute).to eq('bar')
       end
 
       context 'casting without copying the @association cache' do


### PR DESCRIPTION
Hi there!

Apologies for the delay; I've been quite busy lately. However, I'm now sending the solution that addresses the issue I raised some time ago in the pull request.

https://github.com/makandra/active_type/issues/174

The idea is to enable the Active Type Record to have a base method for adding logic after executing the cast. This way, users can easily add business logic as needed.

I hope my contribution will be considered, and I genuinely appreciate your time and attention to this matter. Thank you!