### PR TITLE
Update README.md syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,12 +381,13 @@ sign_up.is_a?(SignUp) # => true
 
 If you need to add some special logic after casting you can add an `after_cast` method:
 
+```ruby
 class SignUp < ActiveType::Record[User]
   def after_cast(user)
     # Called with the original user upon casting.
   end
 end
-
+```
 
 
 Associations
@@ -395,7 +396,7 @@ Associations
 Sometimes, you have an association, and a form model for that association. Instead of always casting the associations manually, you can use the `change_association` macro to override an association's options. For example.
 
 
-```
+```ruby
 class Credential < ActiveRecord::Base
 end
 


### PR DESCRIPTION
Updates the syntax highlighting in the README.

### Before and after

![Firefox - mathewdbuttonactive_type at mbfix-syntax-highlighting 2024-04-12 at 21 01 52@2x](https://github.com/makandra/active_type/assets/1100707/048816d7-2ce7-4f8a-8be2-c87f0333ab62)
