### PR TITLE
Fix `belongs_to` association validation for virtual attributes

### DIFF
--- a/lib/active_type/virtual_attributes.rb
+++ b/lib/active_type/virtual_attributes.rb
@@ -239,6 +239,15 @@ module ActiveType
       super.merge(changes)
     end
 
+    def attribute_changed?(attr, **)
+      attr = attr.to_s
+      if virtual_attributes.key?(attr)
+        virtual_attributes_were[attr] != send(attr)
+      else
+        super
+      end
+    end
+
     if ActiveRecord::VERSION::MAJOR >= 4
       def changes_applied
         super

--- a/spec/shared_examples/belongs_to.rb
+++ b/spec/shared_examples/belongs_to.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'a belongs_to association' do |association, klass|
+shared_examples_for 'a required belongs_to association' do |association, klass|
 
   let(:record) { klass.create }
 
@@ -14,4 +14,44 @@ shared_examples_for 'a belongs_to association' do |association, klass|
     expect(subject.send("#{association}")).to eq(record)
   end
 
+  it 'is invalid if the associated record is not found' do
+    subject.send("#{association}_id=", -1)
+
+    expect(subject).to be_invalid
+  end
+
+  it 'is invalid if the assigned id is nil' do
+    subject.send("#{association}_id=", nil)
+
+    expect(subject).to be_invalid
+  end
+end
+
+shared_examples_for 'an optional belongs_to association' do |association, klass|
+
+  let(:record) { klass.create }
+
+  it 'sets the id when assigning a record' do
+    subject.send("#{association}=", record)
+
+    expect(subject.send("#{association}_id")).to eq(record.id)
+  end
+
+  it 'sets the record when assigning an id' do
+    subject.send("#{association}_id=", record.id)
+
+    expect(subject.send("#{association}")).to eq(record)
+  end
+
+  it 'is valid even if the associated record is not found' do
+    subject.send("#{association}_id=", -1)
+
+    expect(subject).to be_valid
+  end
+
+  it 'is valid even if the assigned id is nil' do
+    subject.send("#{association}_id=", nil)
+
+    expect(subject).to be_valid
+  end
 end

--- a/spec/shared_examples/dirty_tracking.rb
+++ b/spec/shared_examples/dirty_tracking.rb
@@ -103,4 +103,28 @@ shared_examples_for "a class supporting dirty tracking for virtual attributes" d
     end
 
   end
+
+  describe '#attribute_changed?' do
+    it 'returns true if specified attribute is not nil' do
+      subject.virtual_attribute = 'foo'
+      expect(subject.attribute_changed?(:virtual_attribute)).to eq(true)
+    end
+
+    it 'returns false if specified attribute is nil' do
+      subject.virtual_attribute = nil
+      expect(subject.attribute_changed?(:virtual_attribute)).to eq(false)
+    end
+
+    context 'after applying changes' do
+      it 'returns false' do
+        subject.virtual_attribute = 'foo'
+        subject.changes_applied
+        expect(subject.attribute_changed?(:virtual_attribute)).to eq(false)
+      end
+    end
+
+    it 'returns false if specified attribute does not exist' do
+      expect(subject.attribute_changed?(:not_exist)).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
`belongs_to` associations in `ActiveType::Object` did not properly validate presence when `ActiveRecord::Base.belongs_to_required_by_default = true` and `ActiveRecord.belongs_to_required_validates_foreign_key = false` (Rails default).

```ruby
require "bundler/inline"

gemfile do
  source "https://rubygems.org"
  gem "activerecord"
  gem "sqlite3"
  gem "active_type"
end

require "active_record"
require "sqlite3"
require "active_type"

ActiveRecord::Base.belongs_to_required_by_default = true
ActiveRecord.belongs_to_required_validates_foreign_key = false

ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")

ActiveRecord::Schema.define do
  create_table :shops do |t|
  end

  create_table :items do |t|
    t.references :shop, null: false, foreign_key: true
  end
end

class Shop < ActiveRecord::Base
end

class Item < ActiveRecord::Base
  belongs_to :shop
end

class X < ActiveType::Object
  attribute :shop_id, :integer
  belongs_to :shop
end

p Item.new.valid?              #=> false
p Item.new(shop_id: -1).valid? #=> false
p X.new.valid?                 #=> false
p X.new(shop_id: -1).valid?    #=> true
```

This is because the `validates_presence_of` validation uses `ActiveType::Object#attribute_changed?` and it returns always `false` for virtual attributes.

```ruby
p X.new(shop_id: 1).attribute_changed?(:shop_id) #=> false
```

https://github.com/rails/rails/blob/v8.0.1/activerecord/lib/active_record/associations/builder/belongs_to.rb#L135

This commit implements `ActiveType::VirtualAttributes#attribute_changed?` and fixes the problem.

The same applies to `ActiveType::Record`.