### PR TITLE
Fix record lookup when id is given as string

### DIFF
--- a/lib/active_type/nested_attributes/association.rb
+++ b/lib/active_type/nested_attributes/association.rb
@@ -97,7 +97,7 @@ module ActiveType
       end
 
       def fetch_child(parent, id)
-        assigned = assigned_children(parent).detect { |r| r.id == id }
+        assigned = assigned_children(parent).detect { |r| r.id.to_s == id.to_s }
         return assigned if assigned
 
         if child = find_scope(parent).find_by_id(id)

--- a/spec/active_type/nested_attributes_spec.rb
+++ b/spec/active_type/nested_attributes_spec.rb
@@ -235,6 +235,19 @@ describe "ActiveType::Object" do
         should_assign_and_persist(["existing 1", "updated", "existing 3"])
       end
 
+      it 'allows the id to be given as a string' do
+        subject.records = [
+          NestedAttributesSpec::Record.new(:persisted_string => "existing 1"),
+          NestedAttributesSpec::Record.new(:persisted_string => "existing 2"),
+        ]
+        subject.records[0].id = 100
+        subject.records[1].id = 101
+
+        subject.records_attributes = { '1' => { 'id' => '101', 'persisted_string' => 'updated' } }
+
+        should_assign_and_persist(["existing 1", "updated"])
+      end
+
       it 'does not update records matching a reject_if proc' do
         extra_options.merge!(:reject_if => :bad)
         subject.records = [


### PR DESCRIPTION
Given I have the following setup

```rb
class UserUpdater < ActiveType::Object
  nests_many :users
end
```

Now, I have a route that updates all admins. I want to use the UserUpdater like this:
```rb
updater = UserUpdater.new(users: User.admin.includes(:association).to_a)
updater.attributes = {
  'users_attributes' => {
    '1' => { 'id' => '1', last_review: '2025-09-09' },
    '2' => { 'id' => '4', last_review: '2025-09-09' },
  }
}
```

ActiveType doesn't use the given user array to locate the users and loads all given users seperately, causing far more database queries than needed. The issue seems to be that it checks all existing records for whether their id equals the id from the attributes hash. But the id in the loaded records is an integer, the id in the hash is a string, so they never equal.

This PR converts both the id of the existing record and the given id to a string before comparing. This should eliminate this error and will also work with string UUIDs.